### PR TITLE
Add path param to cleanup_files

### DIFF
--- a/basherk.sh
+++ b/basherk.sh
@@ -417,8 +417,12 @@ function check256() {
 
 # remove annoying synology, windows, macos files
 function cleanup_files() {
+    local path="$1"
+
+    [[ -z $path ]] && path="."
+
     # shellcheck disable=SC2033 # ignore warning that xargs rm in this script won't use my rm function
-    find . \( -iname "@eadir" -o -iname "thumbs.db" -o -iname ".ds_store" \) -print0 | xargs -0 rm -ivrf
+    find "$path" \( -iname "@eadir" -o -iname "thumbs.db" -o -iname ".ds_store" \) -print0 | xargs -0 rm -ivrf
 }
 
 # wrapper for git commit

--- a/basherk.sh
+++ b/basherk.sh
@@ -420,7 +420,7 @@ function cleanup_files() {
     local path="${1:-.}"
 
     # shellcheck disable=SC2033 # ignore warning that xargs won't use basherk rm function # "command rm" n/a here
-    find "$path" \( -iname "@eadir" -o -iname ".ds_store" -o -iname "thumbs.db" \) -print0 | xargs -0 rm -ivrf
+    find "$path" \( -iname "@eadir" -o -iname "desktop.ini" -o -iname ".ds_store" -o -iname "thumbs.db" -o -iname ".smbdelete*" \) -print0 | xargs -0 rm -ivrf
 }
 
 # wrapper for git commit

--- a/basherk.sh
+++ b/basherk.sh
@@ -420,7 +420,7 @@ function cleanup_files() {
     local path="${1:-.}"
 
     # shellcheck disable=SC2033 # ignore warning that xargs won't use basherk rm function # "command rm" n/a here
-    find "$path" \( -iname "@eadir" -o -iname "thumbs.db" -o -iname ".ds_store" \) -print0 | xargs -0 rm -ivrf
+    find "$path" \( -iname "@eadir" -o -iname ".ds_store" -o -iname "thumbs.db" \) -print0 | xargs -0 rm -ivrf
 }
 
 # wrapper for git commit

--- a/basherk.sh
+++ b/basherk.sh
@@ -417,9 +417,7 @@ function check256() {
 
 # remove annoying synology, windows, macos files
 function cleanup_files() {
-    local path="$1"
-
-    [[ -z $path ]] && path="."
+    local path="${1:-.}"
 
     # shellcheck disable=SC2033 # ignore warning that xargs rm in this script won't use my rm function
     find "$path" \( -iname "@eadir" -o -iname "thumbs.db" -o -iname ".ds_store" \) -print0 | xargs -0 rm -ivrf

--- a/basherk.sh
+++ b/basherk.sh
@@ -419,7 +419,7 @@ function check256() {
 function cleanup_files() {
     local path="${1:-.}"
 
-    # shellcheck disable=SC2033 # ignore warning that xargs rm in this script won't use my rm function
+    # shellcheck disable=SC2033 # ignore warning that xargs won't use basherk rm function # "command rm" n/a here
     find "$path" \( -iname "@eadir" -o -iname "thumbs.db" -o -iname ".ds_store" \) -print0 | xargs -0 rm -ivrf
 }
 


### PR DESCRIPTION
Previously, `cleanup_files` requires being inside the directory to be cleaned.

Accept a parameter to clean a specified path:
```bash
$ cleanup_files /foo
/foo/bar/.DS_Store
```